### PR TITLE
Inherit from special-mode and add imenu integration

### DIFF
--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -90,6 +90,7 @@ Assume RFC documents are named as e.g. rfc21.txt, rfc-index.txt."
 
 (defvar rfc-mode-map
   (let ((map (make-keymap)))
+    (set-keymap-parent map special-mode-map)
     (define-key map (kbd "q") 'rfc-mode-quit)
     (define-key map (kbd "<prior>") 'rfc-mode-backward-page)
     (define-key map (kbd "<next>") 'rfc-mode-forward-page)

--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -81,10 +81,18 @@ Assume RFC documents are named as e.g. rfc21.txt, rfc-index.txt."
   "The width of the column containing RFC titles in the browser."
   :type 'integer)
 
+(defcustom rfc-mode-imenu-title "RFC Contents"
+  "The title to use if `rfc-mode' adds a RFC Contents menu to the menubar."
+  :type 'string
+  :group 'rfc-mode-group)
+
 ;;; Misc variables:
 
 (defvar rfc-mode-index-entries nil
   "The list of entries in the RFC index.")
+
+(defconst rfc-mode-title-regexp "^\\(?:[0-9]+\\.\\)+\\(?:[0-9]+\\)? .*$"
+  "Regular expression to model section titles in RFC documents.")
 
 ;;; Keys:
 
@@ -102,7 +110,9 @@ Assume RFC documents are named as e.g. rfc21.txt, rfc-index.txt."
 (defun rfc-mode-init ()
   "Initialize the current buffer for `rfc-mode'."
   (setq-local page-delimiter "^.*?\n")
-  (rfc-mode-highlight))
+  (rfc-mode-highlight)
+  (setq imenu-generic-expression (list (list nil rfc-mode-title-regexp 0)))
+  (imenu-add-to-menubar rfc-mode-imenu-title))
 
 (defun rfc-mode-quit ()
   "Quit the current window and bury its buffer."
@@ -173,7 +183,7 @@ Assume RFC documents are named as e.g. rfc21.txt, rfc-index.txt."
       ;; Section titles
       (save-excursion
         (goto-char (point-min))
-        (while (search-forward-regexp "^\\(?:[0-9]+\\.\\)+\\(?:[0-9]+\\)? .*$" nil t)
+        (while (search-forward-regexp rfc-mode-title-regexp nil t)
           (let ((start (match-beginning 0))
                 (end (match-end 0)))
             (put-text-property start end

--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -100,7 +100,6 @@ Assume RFC documents are named as e.g. rfc21.txt, rfc-index.txt."
 
 (defun rfc-mode-init ()
   "Initialize the current buffer for `rfc-mode'."
-  (setq-local buffer-read-only t)
   (setq-local page-delimiter "^.*?\n")
   (rfc-mode-highlight))
 
@@ -146,7 +145,7 @@ Assume RFC documents are named as e.g. rfc21.txt, rfc-index.txt."
         :sources (rfc-mode-browser-helm-sources rfc-mode-index-entries)))
 
 ;;;###autoload
-(define-derived-mode rfc-mode text-mode "rfc-mode"
+(define-derived-mode rfc-mode special-mode "rfc-mode"
   "Major mode to browse and read RFC documents."
   (rfc-mode-init))
 


### PR DESCRIPTION
Thank you for this package! This PR implements some features to make it closer in
functionality to other packages like `man-mode`:

First, inherit from `special-mode` instead of `text-mode`. This already puts the buffer
in read-only mode but, more interestingly, adds a few interesting keybindings for
"view-like" packages like `rpc-mode` (scroll with SPC, S-SPC, etc.).

This PR also adds support for imenu. That lets you navigate more quickly across the
different sections of an RFC document. It adds a menubar option for graphical user 
interfaces as well, see the following screenshot:

<img width="628" alt="Screenshot 2020-07-12 at 5 06 32 PM" src="https://user-images.githubusercontent.com/1573717/87249890-0fd9ea00-c462-11ea-8ea3-9b0a37848ebb.png">

I have a few more features I'd like to implement, but first I want to test the waters with
this PR.