### PR TITLE
Some more rfc-mode features and improvements

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,5 +1,24 @@
 #+TITLE: rfc-mode changelog
 
+* Next Version
+
+** Features
+- ~imenu~ integration. If you use a graphical user interface, the menu
+  bar will show a new menu, "RFC Contents", with links to the
+  different parts of an RFC document.
+- RFC links can now be navigated using the mouse, or by pressing
+  ~<Tab>~/~<S-Tab>~.
+- Pressing ~g~ in a ~rfc-mode~ buffer lets you navigate to an RFC
+  section by name.
+- You can navigate to previous and next RFC sections by pressing ~p~ and
+  ~n~, respectively.
+
+** Misc
+- Derive ~rfc-mode~ from ~special-mode~.
+- Make ~rfc-mode-read~ display the document in a separate window,
+  without switching buffers. This follows the typical Emacs convention
+  for displaying help buffers, like ~help-mode~ or ~man-mode~ follow.
+
 * 1.2.0
 This new release is driven by suggestions from Stefan Monnier and some issues
 which were open on Github. Thanks everyone!

--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -266,7 +266,8 @@ Returns t if section is found, nil otherwise."
             (make-text-button start end
                               'action `(lambda (button)
                                          (rfc-mode-read ,number))
-                              'help-echo (format "Read RFC %d" number))
+                              'help-echo (format "Read RFC %d" number)
+                              'follow-link t)
             (goto-char end)))))))
 
 (defun rfc-mode-header-start ()

--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -100,6 +100,8 @@ Assume RFC documents are named as e.g. rfc21.txt, rfc-index.txt."
   (let ((map (make-keymap)))
     (set-keymap-parent map special-mode-map)
     (define-key map (kbd "q") 'rfc-mode-quit)
+    (define-key map (kbd "<tab>") 'forward-button)
+    (define-key map (kbd "S-<tab>") 'backward-button)
     (define-key map (kbd "<prior>") 'rfc-mode-backward-page)
     (define-key map (kbd "<next>") 'rfc-mode-forward-page)
     (define-key map (kbd "n") 'rfc-mode-next-section)

--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -74,7 +74,7 @@ Assume RFC documents are named as e.g. rfc21.txt, rfc-index.txt."
   :type 'string)
 
 (defcustom rfc-mode-use-original-buffer-names nil
-  "Whether RFC document buffers should keep their original name or not."
+  "Whether RFC document buffers should have the name of the document file (e.g. rfc21.txt vs *rfc21*)."
   :type 'boolean)
 
 (defcustom rfc-mode-browser-entry-title-width 60

--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -166,7 +166,7 @@ Assume RFC documents are named as e.g. rfc21.txt, rfc-index.txt."
 (defun rfc-mode-read (number)
   "Read the RFC document NUMBER."
   (interactive "nRFC number: ")
-  (switch-to-buffer (rfc-mode--document-buffer number)))
+  (display-buffer (rfc-mode--document-buffer number)))
 
 (defun rfc-mode-reload-index ()
   "Reload the RFC document index from its original file."
@@ -373,11 +373,11 @@ The buffer is created if it does not exist."
   (let* ((buffer-name (rfc-mode--document-buffer-name number))
          (document-path (rfc-mode--document-path number)))
     (rfc-mode--fetch-document number document-path)
-    (find-file document-path)
-    (unless rfc-mode-use-original-buffer-names
-      (rename-buffer buffer-name))
-    (rfc-mode)
-    (current-buffer)))
+    (with-current-buffer (find-file-noselect document-path)
+      (unless rfc-mode-use-original-buffer-names
+        (rename-buffer buffer-name))
+      (rfc-mode)
+      (current-buffer))))
 
 ;;; Misc utils:
 

--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -108,7 +108,7 @@ Assume RFC documents are named as e.g. rfc21.txt, rfc-index.txt."
     (set-keymap-parent map special-mode-map)
     (define-key map (kbd "q") 'rfc-mode-quit)
     (define-key map (kbd "<tab>") 'forward-button)
-    (define-key map (kbd "S-<tab>") 'backward-button)
+    (define-key map (kbd "<backtab>") 'backward-button)
     (define-key map (kbd "<prior>") 'rfc-mode-backward-page)
     (define-key map (kbd "<next>") 'rfc-mode-forward-page)
     (define-key map (kbd "g") 'rfc-mode-goto-section)

--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -102,6 +102,8 @@ Assume RFC documents are named as e.g. rfc21.txt, rfc-index.txt."
     (define-key map (kbd "q") 'rfc-mode-quit)
     (define-key map (kbd "<prior>") 'rfc-mode-backward-page)
     (define-key map (kbd "<next>") 'rfc-mode-forward-page)
+    (define-key map (kbd "n") 'rfc-mode-next-section)
+    (define-key map (kbd "p") 'rfc-mode-previous-section)
     map)
   "The keymap for `rfc-mode'.")
 
@@ -132,6 +134,31 @@ Assume RFC documents are named as e.g. rfc21.txt, rfc-index.txt."
   (forward-page)
   (rfc-mode-previous-header)
   (recenter 0))
+
+(defun rfc-mode-next-section (n)
+  "Move point to Nth next section (default 1)."
+  (interactive "p")
+  (let ((case-fold-search nil)
+        (start (point)))
+    (if (looking-at rfc-mode-title-regexp)
+	(forward-line 1))
+    (if (re-search-forward rfc-mode-title-regexp (point-max) t n)
+	(beginning-of-line)
+      (goto-char (point-max))
+      ;; The last line doesn't belong to any section.
+      (forward-line -1))
+    ;; Ensure we never move back from the starting point.
+    (if (< (point) start) (goto-char start))))
+
+(defun rfc-mode-previous-section (n)
+  "Move point to Nth previous section (default 1)."
+  (interactive "p")
+  (let ((case-fold-search nil))
+    (if (looking-at rfc-mode-title-regexp)
+	(forward-line -1))
+    (if (re-search-backward rfc-mode-title-regexp (point-min) t n)
+	(beginning-of-line)
+      (goto-char (point-min)))))
 
 ;;;###autoload
 (defun rfc-mode-read (number)


### PR DESCRIPTION
This PR adds more navigation commands to `rfc-mode`.
You can now go to next and previous sections with `n` and `p`, `g` to go
to a particular section by name, and `Tab` and `S-Tab` to navigate
from one RFC link to the next (or previous).

**I've also included one workflow change**: Most help modes in Emacs, including 
`help-mode`, `man-mode`, and others do not switch the current buffer
to show the help buffer. They instead display the help content in a separate window
without switching focus to it. The scenario is that if you are coding and require
information about a Unix command, you can do `M-x man` and the information will
display side by side; you can continue editing your code and scroll the help buffer
with `C-M-v` and `C-M-S-v`. I've implemented the same approach for `rfc-mode`.