### PR TITLE
Add prefix argument support to rfc-mode-read

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -2,6 +2,11 @@
 
 * Next Version
 
+** Features
+
+- ~rfc-mode-read~ now supports a numeric prefix argument, so you can
+  simply type ~C-u 1 2 3 4 M-x rfc-mode-read~ to read RFC number 1234.
+
 * 1.3.0
 This release improves navigation and introduce section detection, thanks to
 Daniel Martín.

--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -199,7 +199,10 @@ Returns t if section is found, nil otherwise."
 ;;;###autoload
 (defun rfc-mode-read (number)
   "Read the RFC document NUMBER."
-  (interactive "nRFC number: ")
+  (interactive
+   (if (and current-prefix-arg (not (consp current-prefix-arg)))
+       (list (prefix-numeric-value current-prefix-arg))
+     (list (read-number "RFC number: "))))
   (display-buffer (rfc-mode--document-buffer number)))
 
 (defun rfc-mode-reload-index ()


### PR DESCRIPTION
It's common for Emacs commands that prompt for a numeric argument in
the minibuffer to also support reading that numeric argument via a
prefix argument. (See `goto-char`, for example.).

* rfc-mode.el (rfc-mode-read): Read a prefix numeric argument and use
it as the "number" argument; prompt in the minibuffer if no prefix
argument was used.
* changelog.org (Features): Advertise the change.