### PR TITLE
Offer number at point as default in rfc-mode-read

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -5,7 +5,9 @@
 ** Features
 
 - ~rfc-mode-read~ now supports a numeric prefix argument, so you can
-  simply type ~C-u 1 2 3 4 M-x rfc-mode-read~ to read RFC number 1234.
+  simply type ~C-u 1 2 3 4 M-x rfc-mode-read~ to read RFC
+  number 1234. Also, if you call ~rfc-mode-read~ when point is on a
+  number, you will be offered that number as default.
 
 * 1.3.0
 This release improves navigation and introduce section detection, thanks to

--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -196,11 +196,24 @@ Returns t if section is found, nil otherwise."
 
 ;;;###autoload
 (defun rfc-mode-read (number)
-  "Read the RFC document NUMBER."
+  "Read the RFC document NUMBER.
+Offer the number at point as default."
   (interactive
    (if (and current-prefix-arg (not (consp current-prefix-arg)))
        (list (prefix-numeric-value current-prefix-arg))
-     (list (read-number "RFC number: "))))
+     (let ((default
+             ;; Note that we don't use `number-at-point' as it will
+             ;; match number formats that make no sense as RFC numbers
+             ;; (floating point, hexadecimal, etc.).
+	     (save-excursion
+	       (skip-chars-backward "0-9")
+	       (if (looking-at "[0-9]")
+		   (string-to-number
+		    (buffer-substring-no-properties
+		     (point)
+		     (progn (skip-chars-forward "0-9")
+			    (point))))))))
+       (list (read-number "RFC number: " default)))))
   (display-buffer (rfc-mode--document-buffer number)))
 
 (defun rfc-mode-reload-index ()


### PR DESCRIPTION
Now if you call rfc-mode-read when point is on a number,
you can simply press RET to open that RFC number.