### PR TITLE
Free rfc-mode-browse of the dependency on Helm

### DIFF
--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -201,19 +201,7 @@ Offer the number at point as default."
   (interactive
    (if (and current-prefix-arg (not (consp current-prefix-arg)))
        (list (prefix-numeric-value current-prefix-arg))
-     (let ((default
-             ;; Note that we don't use `number-at-point' as it will
-             ;; match number formats that make no sense as RFC numbers
-             ;; (floating point, hexadecimal, etc.).
-	     (save-excursion
-	       (skip-chars-backward "0-9")
-	       (if (looking-at "[0-9]")
-		   (string-to-number
-		    (buffer-substring-no-properties
-		     (point)
-		     (progn (skip-chars-forward "0-9")
-			    (point))))))))
-       (list (read-number "RFC number: " default)))))
+     (list (read-number "RFC number: " (rfc-mode--integer-at-point)))))
   (display-buffer (rfc-mode--document-buffer number)))
 
 (defun rfc-mode-reload-index ()
@@ -435,6 +423,19 @@ The buffer is created if it does not exist."
       (current-buffer))))
 
 ;;; Misc utils:
+
+(defun rfc-mode--integer-at-point ()
+  ;; Note that we don't use `number-at-point' as it will match
+  ;; number formats that make no sense as RFC numbers (floating
+  ;; point, hexadecimal, etc.).
+  (save-excursion
+    (skip-chars-backward "0-9")
+    (and (looking-at "[0-9]")
+	 (string-to-number
+	  (buffer-substring-no-properties
+	   (point)
+	   (progn (skip-chars-forward "0-9")
+		  (point)))))))
 
 (defun rfc-mode--fetch-document (suffix document-path)
   "Ensure an RFC document with SUFFIX exists at DOCUMENT-PATH.


### PR DESCRIPTION
Packages that are not intrinsically tied to some completion mode,
should not depend on such a package, to avoid forcing the authors
preference on innocent users. [This is the policy that we use, I
guess `rfc-mode` was added before we started asking authors to
follow this convention.]

This change shouldn't disturb existing users because we keep using
`helm` if it is available.

Usually optional `helm` support should be implemented in a separate
library, which should be distributed as a separate package, but since
here `helm` support consists of only two short functions, we can skip
that here.