### PR TITLE
Fix completing-read default argument

### DIFF
--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -321,8 +321,8 @@ Offer the number at point as default."
                 (number (string-to-number (match-string 1))))
             (unless (= start (line-beginning-position))
               (make-text-button start end
-                                'action `(lambda (button)
-                                           (rfc-mode-read ,number))
+                                'action (lambda (_button)
+                                          (rfc-mode-read number))
                                 'help-echo (format "Read RFC %d" number)
                                 'follow-link t))
             (goto-char end)))))))

--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -29,6 +29,9 @@
 (require 'pcase)
 (require 'seq)
 
+(eval-when-compile
+  (require 'cl-lib))
+
 (declare-function helm-build-sync-source "helm-source")
 (declare-function helm-make-actions "helm-lib")
 


### PR DESCRIPTION
* `rfc-mode.el` (`rfc-mode-browse`): Don't pass a numeric `default` argument for `completing-read` to `rfc-mode-browser-format-candidate`, which expects a plist argument.  Instead, use the appropriate completion candidate as the default.  Also fix a thinko in the subsequent error message, and reuse `rfc-mode-reload-index`.

Fixes #15.

I include also a couple of small unrelated cleanup commits. Let me know if you'd prefer I submit those separately. Thanks.