### PR TITLE
Unify redisplay after jumps, scrolling point to or near window top

### DIFF
--- a/rfc-mode.el
+++ b/rfc-mode.el
@@ -153,19 +153,24 @@ If nil (the default) then use e.g. *rfc21*, otherwise use e.g. rfc21.txt."
 
 (define-obsolete-function-alias 'rfc-mode-quit #'quit-window "rfc-mode-1.4")
 
+(defun rfc-mode-recenter ()
+  "Do the same as `recenter-top-bottom' would for the `top' position."
+  (let ((recenter-positions '(top)))
+    (recenter-top-bottom)))
+
 (defun rfc-mode-backward-page ()
   "Scroll to the previous page of the current buffer."
   (interactive)
   (backward-page)
   (rfc-mode-previous-header)
-  (recenter 0))
+  (rfc-mode-recenter))
 
 (defun rfc-mode-forward-page ()
   "Scroll to the next page of the current buffer."
   (interactive)
   (forward-page)
   (rfc-mode-previous-header)
-  (recenter 0))
+  (rfc-mode-recenter))
 
 (defun rfc-mode-goto-section (section)  ;FIXME: Why not use imenu for that?
   "Move point to SECTION."
@@ -189,7 +194,10 @@ Returns t if section is found, nil otherwise."
         (case-fold-search nil))
     (goto-char (point-min))
     (if (re-search-forward (concat "^" section) (point-max) t)
-        (progn (beginning-of-line) t)
+        (progn
+          (beginning-of-line)
+          (rfc-mode-recenter)
+          t)
       (goto-char curpos)
       nil)))
 
@@ -201,7 +209,9 @@ Returns t if section is found, nil otherwise."
     (if (looking-at rfc-mode-title-regexp)
         (forward-line 1))
     (if (re-search-forward rfc-mode-title-regexp (point-max) t n)
-        (beginning-of-line)
+        (progn
+          (beginning-of-line)
+          (rfc-mode-recenter))
       (goto-char (point-max))
       ;; The last line doesn't belong to any section.
       (forward-line -1))
@@ -215,7 +225,9 @@ Returns t if section is found, nil otherwise."
     (if (looking-at rfc-mode-title-regexp)
         (forward-line -1))
     (if (re-search-backward rfc-mode-title-regexp (point-min) t n)
-        (beginning-of-line)
+        (progn
+          (beginning-of-line)
+          (rfc-mode-recenter))
       (goto-char (point-min)))))
 
 ;;;###autoload


### PR DESCRIPTION
Jumping to a section and leaving point near page bottom makes for
strange user experience.

`rfc-mode-{backward,forward}-page` did scroll the new position to
window top already; unify the behavior using new `rfc-mode-recenter`
function, reusing the `recenter-top-bottom` machinery to respect
`scroll-margin` et al.

_Edited to fix Markdown formatting_